### PR TITLE
Simplify classification

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -24,11 +24,11 @@ Tested-With: GHC ==8.8.4 || ==8.10.4 || ==9.0.1
 
 library
     exposed-modules:  Debug.RecoverRTTI
+                      Debug.RecoverRTTI.Classify
                       Debug.RecoverRTTI.ClosureTree
 
     other-modules:    Debug.RecoverRTTI.CheckSame
                       Debug.RecoverRTTI.Classifier
-                      Debug.RecoverRTTI.Classify
                       Debug.RecoverRTTI.Constraint
                       Debug.RecoverRTTI.FlatClosure
                       Debug.RecoverRTTI.Modules

--- a/src/Debug/RecoverRTTI.hs
+++ b/src/Debug/RecoverRTTI.hs
@@ -7,13 +7,11 @@ module Debug.RecoverRTTI (
   , Classifier
   , PrimClassifier(..)
   , IsUserDefined(..)
-  , Classifiers(..)
     -- ** Generalizations
   , Classifier_(..)
     -- ** Unknown or partially known type arguments
-  , MaybeF(..)
-  , EitherF(..)
-  , MaybePairF(..)
+  , Elem(..)
+  , Elems(..)
     -- ** Newtype wrappers for unshowable types
   , SomeSTRef(..)
   , SomeTVar(..)
@@ -31,6 +29,8 @@ module Debug.RecoverRTTI (
     -- ** Equality
   , samePrim
   , sameClassifier_
+  , sameElem
+  , sameElems
     -- * User-defined types
   , UserDefined -- opaque
     -- ** Classify constructor arguments

--- a/tests/Test/RecoverRTTI/Classifier/Equality.hs
+++ b/tests/Test/RecoverRTTI/Classifier/Equality.hs
@@ -1,34 +1,12 @@
-{-# LANGUAGE RankNTypes #-}
-
--- | Equality
---
--- This is not defined in the main lib, because this depends on orphan 'Eq'
--- instances, some of which are a bit dubious (especially some of the ones
--- defined in "Test.RecoverRTTI.Prim").
-module Test.RecoverRTTI.Classifier.Equality (canCompareClassified_) where
+-- | Equality orphan instances
+module Test.RecoverRTTI.Classifier.Equality () where
 
 import Data.Function (on)
-import Data.SOP.Dict
 
 import qualified Data.HashMap.Internal.Array as HashMap (Array)
 import qualified Data.HashMap.Internal.Array as HashMap.Array
 
-import Debug.RecoverRTTI
-
 import Test.RecoverRTTI.Prim ()
-
-{-------------------------------------------------------------------------------
-  All types recognized by the library have Eq instances
--------------------------------------------------------------------------------}
-
-canCompareClassified_ :: forall o.
-     (forall a. o a -> Dict Eq a)
-  -> (forall a. Classifier_ o a -> Dict Eq a)
-canCompareClassified_ = classifiedSatisfies
-
-{-------------------------------------------------------------------------------
-  Orphan Eq instances
--------------------------------------------------------------------------------}
 
 instance Eq a => Eq (HashMap.Array a) where
   (==) = (==) `on` HashMap.Array.toList

--- a/tests/Test/RecoverRTTI/Classifier/Size.hs
+++ b/tests/Test/RecoverRTTI/Classifier/Size.hs
@@ -21,33 +21,25 @@ classifierSize_ sizeOther = go
     go :: Classifier_ o a -> Int
     go (C_Prim         _) = 1
     go (C_Other        c) = sizeOther c
-    go (C_Maybe        c) = 1 + goMaybeF     c
-    go (C_Either       c) = 1 + goEitherF    c
-    go (C_List         c) = 1 + goMaybeF     c
-    go (C_Ratio        c) = 1 + go           c
-    go (C_Set          c) = 1 + goMaybeF     c
-    go (C_Map          c) = 1 + goMaybePairF c
-    go (C_IntMap       c) = 1 + goMaybeF     c
-    go (C_Sequence     c) = 1 + goMaybeF     c
-    go (C_Tree         c) = 1 + go           c
-    go (C_HashSet      c) = 1 + go           c
-    go (C_HashMap      c) = 1 + goMaybePairF c
-    go (C_HM_Array     c) = 1 + goMaybeF     c
-    go (C_Prim_Array   c) = 1 + goMaybeF     c
-    go (C_Vector_Boxed c) = 1 + goMaybeF     c
-    go (C_Tuple        c) = 1 + goTuple      c
+    go (C_Maybe        c) = 1 + goElems c
+    go (C_Either       c) = 1 + goElems c
+    go (C_List         c) = 1 + goElems c
+    go (C_Ratio        c) = 1 + goElems c
+    go (C_Set          c) = 1 + goElems c
+    go (C_Map          c) = 1 + goElems c
+    go (C_IntMap       c) = 1 + goElems c
+    go (C_Sequence     c) = 1 + goElems c
+    go (C_Tree         c) = 1 + goElems c
+    go (C_HashSet      c) = 1 + goElems c
+    go (C_HashMap      c) = 1 + goElems c
+    go (C_HM_Array     c) = 1 + goElems c
+    go (C_Prim_Array   c) = 1 + goElems c
+    go (C_Vector_Boxed c) = 1 + goElems c
+    go (C_Tuple        c) = 1 + goElems c
 
-    goMaybeF :: MaybeF o a -> Int
-    goMaybeF FNothing  = 0
-    goMaybeF (FJust c) = go c
+    goElems :: SListI as => Elems o as -> Int
+    goElems (Elems cs) = sum . hcollapse $ hmap (K . goElem) cs
 
-    goEitherF :: EitherF o a b -> Int
-    goEitherF (FLeft  c) = go c
-    goEitherF (FRight c) = go c
-
-    goMaybePairF :: MaybePairF o a b -> Int
-    goMaybePairF FNothingPair     = 0
-    goMaybePairF (FJustPair c c') = go c + go c'
-
-    goTuple :: SListI xs => Classifiers o xs -> Int
-    goTuple = sum . hcollapse . hmap (K . go) . getClassifiers
+    goElem :: Elem o a -> Int
+    goElem NoElem   = 0
+    goElem (Elem c) = go c

--- a/tests/Test/RecoverRTTI/Classify.hs
+++ b/tests/Test/RecoverRTTI/Classify.hs
@@ -32,6 +32,7 @@ import Test.Tasty
 import Test.Tasty.QuickCheck hiding (classify, NonEmpty)
 
 import Debug.RecoverRTTI
+import Debug.RecoverRTTI.Classify
 
 import Test.RecoverRTTI.ConcreteClassifier
 import Test.RecoverRTTI.Globals
@@ -134,73 +135,73 @@ prop_constants = withMaxSuccess 1 $ conjoin [
 
       -- Compound
 
-    , compareClassifier $ Value (C_Maybe FNothing) $
+    , compareClassifier $ Value (C_Maybe ElemNothing) $
         Nothing
-    , compareClassifier $ Value (C_Maybe (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_Maybe (ElemJust (C_Prim C_Int))) $
         Just 3
 
-    , compareClassifier $ Value (C_Either (FLeft (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_Either (ElemLeft (C_Prim C_Int))) $
         Left 3
-    , compareClassifier $ Value (C_Either (FRight (C_Prim C_Bool))) $
+    , compareClassifier $ Value (C_Either (ElemRight (C_Prim C_Bool))) $
         Right True
 
-    , compareClassifier $ Value (C_List FNothing) $
+    , compareClassifier $ Value (C_List ElemNothing) $
         []
-    , compareClassifier $ Value (C_List (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_List (ElemJust (C_Prim C_Int))) $
         [1, 2, 3]
 
-    , compareClassifier $ Value (C_Tuple (Classifiers (C_Prim C_Int :* C_Prim C_Char :* Nil))) $
+    , compareClassifier $ Value (C_Tuple (Elems (Elem (C_Prim C_Int) :* Elem (C_Prim C_Char) :* Nil))) $
         WrappedTuple (4, 'a')
-    , compareClassifier $ Value (C_Tuple (Classifiers (C_Prim C_Int :* C_Prim C_Char :* C_Prim C_Bool :* Nil))) $
+    , compareClassifier $ Value (C_Tuple (Elems (Elem (C_Prim C_Int) :* Elem (C_Prim C_Char) :* Elem (C_Prim C_Bool) :* Nil))) $
         WrappedTuple (4, 'a', True)
 
-    , compareClassifier $ Value (C_Ratio (C_Prim C_Integer)) $
+    , compareClassifier $ Value (C_Ratio (ElemJust (C_Prim C_Integer))) $
         1 % 2
 
-    , compareClassifier $ Value (C_Set FNothing) $
+    , compareClassifier $ Value (C_Set ElemNothing) $
         Set.empty
-    , compareClassifier $ Value (C_Set (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_Set (ElemJust (C_Prim C_Int))) $
         Set.fromList [1, 2, 3]
 
-    , compareClassifier $ Value (C_Map FNothingPair) $
+    , compareClassifier $ Value (C_Map ElemNothingPair) $
         Map.empty
-    , compareClassifier $ Value (C_Map (FJustPair (C_Prim C_Int) (C_Prim C_Char))) $
+    , compareClassifier $ Value (C_Map (ElemJustPair (C_Prim C_Int) (C_Prim C_Char))) $
         Map.fromList [(1, 'a'), (2, 'b')]
 
-    , compareClassifier $ Value (C_IntMap FNothing) $
+    , compareClassifier $ Value (C_IntMap ElemNothing) $
         IntMap.empty
-    , compareClassifier $ Value (C_IntMap (FJust (C_Prim C_Char))) $
+    , compareClassifier $ Value (C_IntMap (ElemJust (C_Prim C_Char))) $
         IntMap.fromList [(1, 'a'), (2, 'b')]
 
-    , compareClassifier $ Value (C_Sequence FNothing) $
+    , compareClassifier $ Value (C_Sequence ElemNothing) $
         Seq.empty
-    , compareClassifier $ Value (C_Sequence (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_Sequence (ElemJust (C_Prim C_Int))) $
         Seq.fromList [1, 2, 3]
 
-    , compareClassifier $ Value (C_Tree (C_Prim C_Int)) $
+    , compareClassifier $ Value (C_Tree (ElemJust (C_Prim C_Int))) $
         Tree.Node 1 []
 
-    , compareClassifier $ Value (C_HashSet (C_Prim C_Int)) $
+    , compareClassifier $ Value (C_HashSet (ElemJust (C_Prim C_Int))) $
         HashSet.fromList [1, 2, 3]
 
-    , compareClassifier $ Value (C_HashMap FNothingPair) $
+    , compareClassifier $ Value (C_HashMap ElemNothingPair) $
         HashMap.empty
-    , compareClassifier $ Value (C_HashMap (FJustPair (C_Prim C_Int) (C_Prim C_Char))) $
+    , compareClassifier $ Value (C_HashMap (ElemJustPair (C_Prim C_Int) (C_Prim C_Char))) $
         HashMap.fromList [(1, 'a'), (2, 'b')]
 
-    , compareClassifier $ Value (C_HM_Array FNothing) $
+    , compareClassifier $ Value (C_HM_Array ElemNothing) $
         HashMap.Array.fromList 0 []
-    , compareClassifier $ Value (C_HM_Array (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_HM_Array (ElemJust (C_Prim C_Int))) $
         HashMap.Array.fromList 2 [1, 2]
 
-    , compareClassifier $ Value (C_Prim_Array FNothing) $
+    , compareClassifier $ Value (C_Prim_Array ElemNothing) $
         Prim.Array.arrayFromList []
-    , compareClassifier $ Value (C_Prim_Array (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_Prim_Array (ElemJust (C_Prim C_Int))) $
         Prim.Array.arrayFromList [1, 2, 3]
 
-    , compareClassifier $ Value (C_Vector_Boxed FNothing) $
+    , compareClassifier $ Value (C_Vector_Boxed ElemNothing) $
         Vector.Boxed.empty
-    , compareClassifier $ Value (C_Vector_Boxed (FJust (C_Prim C_Int))) $
+    , compareClassifier $ Value (C_Vector_Boxed (ElemJust (C_Prim C_Int))) $
         Vector.Boxed.fromList [1, 2, 3]
 
       -- User defined
@@ -210,14 +211,14 @@ prop_constants = withMaxSuccess 1 $ conjoin [
     , compareClassifier $ Value (C_Other C_Simple) $
         SimpleB
 
-    , compareClassifier $ Value (C_Other (C_NonRec FNothing))  $
+    , compareClassifier $ Value (C_Other (C_NonRec ElemNothing))  $
         (NR1 1234)
-    , compareClassifier $ Value (C_Other (C_NonRec (FJust (C_Prim C_Char)))) $
+    , compareClassifier $ Value (C_Other (C_NonRec (ElemJust (C_Prim C_Char)))) $
         (NR2 True 'a')
 
-    , compareClassifier $ Value (C_Other (C_Rec FNothing)) $
+    , compareClassifier $ Value (C_Other (C_Rec ElemNothing)) $
         RNil
-    , compareClassifier $ Value (C_Other (C_Rec (FJust (C_Prim C_Char)))) $
+    , compareClassifier $ Value (C_Other (C_Rec (ElemJust (C_Prim C_Char)))) $
         (RCons 'a' RNil)
 
     , compareClassifier $ Value (C_Other C_Unlifted) $


### PR DESCRIPTION
Currently we have all these different shapes, and it's making it difficult to
add other datatypes. We don't actually benefit from this very much, so we
should simplify. The resulting code is a lot simpler and more uniform.