### PR TITLE
Simplify reclassification

### DIFF
--- a/src/Debug/RecoverRTTI.hs
+++ b/src/Debug/RecoverRTTI.hs
@@ -50,6 +50,8 @@ module Debug.RecoverRTTI (
   , Reclassified(..)
   , reclassify_
   , distribReclassified
+  , FromUsr(..)
+  , coerceFromUsr
     -- * Inductive tuples
   , WrappedTuple(WrappedTuple, TNil, TCons)
   , unwrapTuple

--- a/src/Debug/RecoverRTTI/Tuple.hs
+++ b/src/Debug/RecoverRTTI/Tuple.hs
@@ -83,16 +83,17 @@ tupleToNP (TCons x xs) = I x :* tupleToNP xs
   Mapping
 -------------------------------------------------------------------------------}
 
-data PairWise xs ys where
-  PNil  :: PairWise '[] '[]
-  PCons :: (x -> y) -> PairWise xs ys -> PairWise (x:xs) (y:ys)
+data PairWise f xs ys where
+  PNil  :: PairWise f '[] '[]
+  PCons :: f x y -> PairWise f xs ys -> PairWise f (x:xs) (y:ys)
 
 data SameListShape xs ys where
   SameListShape :: (SListI ys, Length xs ~ Length ys) => SameListShape xs ys
 
 mapTuple' ::
      (SListI xs, IsValidSize (Length xs))
-  => PairWise xs ys -> WrappedTuple xs -> (SameListShape xs ys, WrappedTuple ys)
+  => PairWise (->) xs ys
+  -> WrappedTuple xs -> (SameListShape xs ys, WrappedTuple ys)
 mapTuple' PNil          TNil        = (SameListShape, TNil)
 mapTuple' (PCons f fs) (TCons x xs) =
     case mapTuple' fs xs of
@@ -100,7 +101,7 @@ mapTuple' (PCons f fs) (TCons x xs) =
 
 mapTuple ::
      (SListI xs, IsValidSize (Length xs))
-  => PairWise xs ys -> WrappedTuple xs -> WrappedTuple ys
+  => PairWise (->) xs ys -> WrappedTuple xs -> WrappedTuple ys
 mapTuple fs = snd . mapTuple' fs
 
 {-------------------------------------------------------------------------------

--- a/tests/Test/RecoverRTTI/Classify.hs
+++ b/tests/Test/RecoverRTTI/Classify.hs
@@ -316,10 +316,10 @@ compareClassifier = \(Value cc x) ->
         Left err  ->
             counterexample ("Failed to reclassify. Error: " ++ err)
           $ property False
-        Right (Reclassified cc' f) ->
+        Right (Reclassified cc' _pf) ->
           case sameConcrete cc cc' of
             Nothing ->
                 counterexample ("Inferred different classifier: " ++ show cc')
               $ property False
             Just Refl ->
-              x === f x
+              property True

--- a/tests/Test/RecoverRTTI/Staged.hs
+++ b/tests/Test/RecoverRTTI/Staged.hs
@@ -75,7 +75,7 @@ reclassify = fmap distribReclassified . reclassify_ go
     goSimple c constr =
         if constr `notElem` constrsOf (Proxy @a)
           then return Nothing
-          else return . Just $ Reclassified c unsafeCoerce
+          else return . Just $ Reclassified c FromUsr
 
     goTraversable ::
          forall f. (Traversable f, ConstrsOf f)
@@ -87,7 +87,7 @@ reclassify = fmap distribReclassified . reclassify_ go
           return Nothing
         else
           case checkEmptyTraversable (coerceToF x) of
-            Right _ -> return . Just $ Reclassified (cc ElemNothing) coerceToF
+            Right _ -> return . Just $ Reclassified (cc ElemNothing) FromUsr
             Left x' -> Just . aux <$> classifyConcrete x'
       where
         coerceToF :: forall a. UserDefined -> f a
@@ -96,7 +96,8 @@ reclassify = fmap distribReclassified . reclassify_ go
         aux ::
              Reclassified ConcreteClassifier a
           -> Reclassified ClassifyUser UserDefined
-        aux (Reclassified c f) = Reclassified (cc (ElemJust c)) (fmap f . coerceToF)
+        aux (Reclassified c pf) =
+            Reclassified (cc (ElemJust c)) (F1 pf `Compose` FromUsr)
 
 {-------------------------------------------------------------------------------
   Auxiliary


### PR DESCRIPTION
We now avoid lifting the coercions, which was awkward and laborious with little benefit. Instead we compute a proof that the coercion is sound. The interpretation of this proof itself is not proven safe by the types, but we can manually inspect it.