### PR TITLE
Prepare for release 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Revision history for recover-rtti
 
+## 0.4 -- 2021-06-30
+
+* Correctly set some required lower bounds.
+* Add support for reclassification
+* Add classification equality check
+* Add support for primitive arrays and vectors
+* Fix classification on OSX
+* General internal cleanup of the library
+
+This release is backwards incompatible with 0.3, but users that simply use
+`anythingToString` should be unaffected.
+
 ## 0.3.0.0 -- 2021-03-17
 
 * Fix bug that could cause `anythingToString` to fail on lists with an

--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               recover-rtti
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           Recover run-time type information from the GHC heap
 description:        The main function in this package is 'classify', which looks
                     at the GHC heap to recover type information about arbitrary
@@ -40,18 +40,24 @@ library
                       Debug.RecoverRTTI.Util
                       Debug.RecoverRTTI.Wrappers
 
-    build-depends:    base                 >= 4.13  && < 4.16
-                    , aeson                >= 1.4   && < 1.6
-                    , bytestring           >= 0.10  && < 0.11
-                    , containers           >= 0.6   && < 0.7
-                    , ghc-heap             >= 8.8   && < 9.1
-                    , mtl                  >= 2.2   && < 2.3
-                    , primitive
-                    , sop-core             >= 0.5   && < 0.6
-                    , stm                  >= 2.5   && < 2.6
-                    , text                 >= 1.2   && < 1.3
-                    , unordered-containers
-                    , vector
+    build-depends:    base                 >= 4.13     && < 4.16
+                    , aeson                >= 1.4      && < 1.6
+                    , bytestring           >= 0.10     && < 0.11
+                    , containers           >= 0.6      && < 0.7
+                    , ghc-heap             >= 8.8      && < 9.1
+                    , mtl                  >= 2.2      && < 2.3
+                    , sop-core             >= 0.5      && < 0.6
+                    , stm                  >= 2.5      && < 2.6
+                    , text                 >= 1.2      && < 1.3
+                      -- 0.2.12 introduces Data.HashMap.Internal.Array
+                    , unordered-containers >= 0.2.12   && < 0.3
+
+                      -- THe oldest ghc we support is 8.8.
+		      -- The dependencies below are the oldest versions of
+		      -- these packages that compile with this ghc version.
+                    , vector               >= 0.12.1.2 && < 0.13
+                    , primitive            >= 0.7      && < 0.8
+
     hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:      -Wall

--- a/tests/Test/RecoverRTTI/Classifier/Arbitrary.hs
+++ b/tests/Test/RecoverRTTI/Classifier/Arbitrary.hs
@@ -139,8 +139,8 @@ arbitraryClassifier_  genOther = go
           go_U_K C_HM_Array (mkArray [])
             (mapSome (GenK (SG.genListLike mkArray)) <$> go)
 
-        , go_U_K C_Prim_Array (Prim.Array.arrayFromList [])
-            (mapSome (GenK (SG.genListLike Prim.Array.arrayFromList)) <$> go)
+        , go_U_K C_Prim_Array (Prim.Array.fromList [])
+            (mapSome (GenK (SG.genListLike Prim.Array.fromList)) <$> go)
 
         , go_U_K C_Vector_Boxed Vector.Boxed.empty
             (mapSome (GenK (SG.genListLike Vector.Boxed.fromList)) <$> go)

--- a/tests/Test/RecoverRTTI/Classify.hs
+++ b/tests/Test/RecoverRTTI/Classify.hs
@@ -195,9 +195,9 @@ prop_constants = withMaxSuccess 1 $ conjoin [
         HashMap.Array.fromList 2 [1, 2]
 
     , compareClassifier $ Value (C_Prim_Array ElemU) $
-        Prim.Array.arrayFromList []
+        Prim.Array.fromList []
     , compareClassifier $ Value (C_Prim_Array (ElemK (C_Prim C_Int))) $
-        Prim.Array.arrayFromList [1, 2, 3]
+        Prim.Array.fromList [1, 2, 3]
 
     , compareClassifier $ Value (C_Vector_Boxed ElemU) $
         Vector.Boxed.empty


### PR DESCRIPTION
* Lower bounds
* Bump version
* Update ChangeLog
* Support older versions of primitive

Closes #8.