### PR TITLE
Enable building with mtl-2.3

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -50,7 +50,7 @@ library
                     , bytestring           >= 0.10     && < 0.12
                     , containers           >= 0.6      && < 0.7
                     , ghc-heap             >= 8.8      && < 9.3
-                    , mtl                  >= 2.2      && < 2.3
+                    , mtl                  >= 2.2      && < 2.4
                     , sop-core             >= 0.5      && < 0.6
                     , stm                  >= 2.5      && < 2.6
                     , text                 >= 1.2      && < 2.1

--- a/src/Debug/RecoverRTTI/Classify.hs
+++ b/src/Debug/RecoverRTTI/Classify.hs
@@ -36,7 +36,9 @@ module Debug.RecoverRTTI.Classify (
   , pattern ElemUK
   ) where
 
+import Control.Monad
 import Control.Monad.Except
+import Control.Monad.Trans
 import Data.HashMap.Lazy (HashMap)
 import Data.IntMap (IntMap)
 import Data.Map (Map)


### PR DESCRIPTION
`Control.Monad` reexports were removed