### PR TITLE
allow aeson-2.1

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -46,7 +46,7 @@ library
                       Debug.RecoverRTTI.Wrappers
 
     build-depends:    base       >= 4.13 && < 4.17
-                    , aeson      >= 1.4  && < 2.1
+                    , aeson      >= 1.4  && < 2.2
                     , bytestring >= 0.10 && < 0.12
                     , containers >= 0.6  && < 0.7
                     , ghc-heap   >= 8.8  && < 9.3


### PR DESCRIPTION
This project builds successfully with `aeson==2.1*`, and I looked over the [changelog](https://hackage.haskell.org/package/aeson-2.1.2.1/changelog). There doesn't seem to be anything that would cause an incompatibility here.

Fixes #28 