### PR TITLE
allow vector-0.13

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -63,7 +63,7 @@ library
                       -- The oldest ghc we support is 8.8.
                       -- The dependencies below are the oldest versions of
                       -- these packages that compile with this ghc version.
-                    , vector    >= 0.12.1.2 && < 0.13
+                    , vector    >= 0.12.1.2 && < 0.14
                     , primitive >= 0.7      && < 0.8
 
     hs-source-dirs:   src


### PR DESCRIPTION
Similar to #26, this builds, and it doesn't look like there's anything problematic in the [changelog](https://hackage.haskell.org/package/vector-0.13.0.0/changelog)