### PR TITLE
allow primitive-0.8

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -64,7 +64,7 @@ library
                       -- The dependencies below are the oldest versions of
                       -- these packages that compile with this ghc version.
                     , vector    >= 0.12.1.2 && < 0.13
-                    , primitive >= 0.7      && < 0.8
+                    , primitive >= 0.7      && < 0.9
 
     hs-source-dirs:   src
     default-language: Haskell2010


### PR DESCRIPTION
This one does build, but only with a `--allow-newer='recover-rtti:aeson'`. So, it relies on #29 

Fixes #32 