### PR TITLE
Support GHC 9.12 + containers 0.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.1
+            compilerKind: ghc
+            compilerVersion: 9.12.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1

--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -27,6 +27,7 @@ Tested-With: GHC ==8.10.7
               || ==9.6.2
               || ==9.8.2
               || ==9.10.1
+              || ==9.12.1
 
 source-repository head
   type:     git
@@ -51,12 +52,12 @@ library
                       Debug.RecoverRTTI.Util
                       Debug.RecoverRTTI.Wrappers
 
-    build-depends:    base       >= 4.13 && < 4.21
+    build-depends:    base       >= 4.13 && < 4.22
                     , aeson      >= 1.4  && < 2.3
                     , bytestring >= 0.10 && < 0.13
                     , containers >= 0.6  && < 0.9
-                    , ghc-heap   >= 8.8  && < 9.11
-                    , ghc-prim   >= 0.5  && < 0.12
+                    , ghc-heap   >= 8.8  && < 9.13
+                    , ghc-prim   >= 0.5  && < 0.14
                     , sop-core   >= 0.5  && < 0.6
                     , stm        >= 2.5  && < 2.6
                     , text       >= 1.2  && < 2.2

--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -54,7 +54,7 @@ library
     build-depends:    base       >= 4.13 && < 4.21
                     , aeson      >= 1.4  && < 2.3
                     , bytestring >= 0.10 && < 0.13
-                    , containers >= 0.6  && < 0.8
+                    , containers >= 0.6  && < 0.9
                     , ghc-heap   >= 8.8  && < 9.11
                     , ghc-prim   >= 0.5  && < 0.12
                     , sop-core   >= 0.5  && < 0.6


### PR DESCRIPTION
Tested all tests work with
```shell
# set GHC 9.12
cabal test --allow-newer --constraint 'base>=4.21' --constraint 'containers>=0.8'
```