### PR TITLE
Bump bounds for QuickCheck

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -138,7 +138,7 @@ test-suite test-recover-rtti
 
   build-depends:
       -- new dependencies
-    , QuickCheck       >= 2.15 && < 2.17
+    , QuickCheck       >= 2.15 && < 2.19
     , tasty            >= 1.5  && < 1.6
     , tasty-hunit      >= 0.10 && < 0.11
     , tasty-quickcheck >= 0.11 && < 0.12

--- a/tests/Test/RecoverRTTI/Classify.hs
+++ b/tests/Test/RecoverRTTI/Classify.hs
@@ -47,13 +47,20 @@ tests = testGroup "Test.RecoverRTTI.Classify" [
     , testProperty "arbitrary" prop_arbitrary
     ]
 
+withNumTests :: QC.Testable prop => Int -> prop -> Property
+#if MIN_VERSION_QuickCheck(2,18,0)
+withNumTests = QC.withNumTests
+#else
+withNumTests = QC.withMaxSuccess
+#endif
+
 -- | Test using manually specified examples
 --
 -- For " normal " code it doesn't matter if something is generated or not,
 -- but their on-heap representation may be different, and this may effect the
 -- RTTI recovery.
 prop_constants :: Property
-prop_constants = QC.withMaxSuccess 1 $ QC.conjoin [
+prop_constants = withNumTests 1 $ QC.conjoin [
       -- Primitive types
 
       compareClassifier $ Value (CC_Prim C_Bool)     True


### PR DESCRIPTION
Validated that this command works:
```bash
cabal test --constraint='QuickCheck==2.18.0.0' --allow-newer=aeson:QuickCheck
```

The only code change is to resolve `-Wdeprecations`, but it shouldn't affect downstream users of recover-rtti

After this merges, I'll make a Hackage revision