### PR TITLE
Bump aeson bounds

### DIFF
--- a/recover-rtti.cabal
+++ b/recover-rtti.cabal
@@ -87,7 +87,7 @@ library
     , text       >= 1.2  && < 2.2
 
   build-depends:
-    , aeson      >= 1.4  && < 2.3
+    , aeson      >= 1.4  && < 2.4
     , sop-core   >= 0.5  && < 0.6
     , vector     >= 0.12 && < 0.14
     , primitive  >= 0.7  && < 0.10


### PR DESCRIPTION
Tested with `cabal test --constraint='aeson==2.3.0.0'`